### PR TITLE
Changed: Only tokenID is needed; Fixed: Server struct

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,17 +37,19 @@ COMMANDS:
 
 GLOBAL OPTIONS:
    --log-level, -l 'info'	Log level (options: debug, info, warn, error, fatal, panic)
+   --scaleway-token     Scaleway Token [$SCALEWAY_TOKEN] (required)
    --scaleway-userid 		Scaleway UserID [$SCALEWAY_USERID]
-   --scaleway-token 		Scaleway Token [$SCALEWAY_TOKEN]
    --scaleway-organization 	Organization identifier [$SCALEWAY_ORGANIZATION]
    --help, -h			show help
    --version, -v		print the version
 
 ```
 
-You must have a **userid**, **tokenid** and **organizationid** to
-use the CLI. You could use command line arguments (in global option), or
-environments variables.
+You must have a **tokenid** to use the CLI.
+By default, commands requiring a **userid** and/or **organizationid** will use the
+user id and primary organization id associated with the token.
+You may specify different id's by setting the corresponding command line arguments
+or environment variables (see GLOBAL OPTIONS).
 
 For each command, subcommands are availables :
 

--- a/src/github.com/nlamirault/go-scaleway/api/client_test.go
+++ b/src/github.com/nlamirault/go-scaleway/api/client_test.go
@@ -41,8 +41,8 @@ func loadJSON(path string) (string, error) {
 
 func getClient() *ScalewayClient {
 	return NewClient(
-		ScalewayUserID,
 		ScalewayToken,
+		ScalewayUserID,
 		ScalewayOrganization)
 }
 

--- a/src/github.com/nlamirault/go-scaleway/api/server.go
+++ b/src/github.com/nlamirault/go-scaleway/api/server.go
@@ -35,7 +35,7 @@ type Server struct {
 	Organization     string   `json:"organization,omitempty"`
 	CreationDate     string   `json:"creation_date,omitempty"`
 	ModificationDate string   `json:"modification_date,omitempty"`
-	Arch             string   `json:"arch,omitempty"`
+	Image            Image    `json:"image,omitempty"`
 	PublicIP         PublicIP `json:"public_ip,omitempty"`
 	State            string   `json:"state,omitempty"`
 	Tags             []string `json:"tags,omitempty"`
@@ -73,9 +73,11 @@ type ServersResponse struct {
 // }
 
 func (s Server) Display() {
-	log.Infof("Id   : %s", s.ID)
-	log.Infof("Name : %s", s.Name)
-	log.Infof("Date : %s", s.ModificationDate)
-	log.Infof("IP   : %s", s.PublicIP.Address)
-	log.Infof("Tags : %s", s.Tags)
+	log.Infof("Id    : %s", s.ID)
+	log.Infof("Name  : %s", s.Name)
+	log.Infof("Image : %s", s.Image.Name)
+	log.Infof("Date  : %s", s.ModificationDate)
+	log.Infof("IP    : %s", s.PublicIP.Address)
+	log.Infof("Tags  : %s", s.Tags)
+	log.Infof("State : %s", s.State)
 }

--- a/src/github.com/nlamirault/go-scaleway/commands/commands.go
+++ b/src/github.com/nlamirault/go-scaleway/commands/commands.go
@@ -84,7 +84,7 @@ var verboseFlag = cli.BoolFlag{
 
 func getClient(c *cli.Context) *api.ScalewayClient {
 	return api.NewClient(
-		c.GlobalString("scaleway-userid"),
 		c.GlobalString("scaleway-token"),
+		c.GlobalString("scaleway-userid"),
 		c.GlobalString("scaleway-organization"))
 }

--- a/src/github.com/nlamirault/go-scaleway/commands/volumes.go
+++ b/src/github.com/nlamirault/go-scaleway/commands/volumes.go
@@ -77,11 +77,6 @@ var commandCreateVolume = cli.Command{
 			Value: "",
 		},
 		cli.StringFlag{
-			Name:  "organizationid",
-			Usage: "Organization unique identifier",
-			Value: "",
-		},
-		cli.StringFlag{
 			Name:  "type",
 			Usage: "The volume type (l_hdd|l_ssd)",
 			Value: "",
@@ -145,18 +140,15 @@ func doDeleteVolume(c *cli.Context) {
 func doCreateVolume(c *cli.Context) {
 	log.Infof("Create volume %s %s %s %s",
 		c.String("name"),
-		c.String("organizationid"),
 		c.String("type"),
 		c.Int("size"))
 	client := getClient(c)
 	// b, err := client.CreateVolume(
 	// 	c.String("name"),
-	// 	c.String("organizationid"),
 	// 	c.String("type"),
 	// 	c.Int("size"))
 	response, err := client.CreateVolume(
 		c.String("name"),
-		c.String("organizationid"),
 		c.String("type"),
 		c.Int("size"))
 	if err != nil {

--- a/src/github.com/nlamirault/go-scaleway/main.go
+++ b/src/github.com/nlamirault/go-scaleway/main.go
@@ -44,16 +44,16 @@ func makeApp() *cli.App {
 			Usage: fmt.Sprintf("Log level (options: debug, info, warn, error, fatal, panic)"),
 		},
 		cli.StringFlag{
-			Name:   "scaleway-userid",
-			Usage:  "Scaleway UserID",
-			Value:  "",
-			EnvVar: "SCALEWAY_USERID",
-		},
-		cli.StringFlag{
 			Name:   "scaleway-token",
 			Usage:  "Scaleway Token",
 			Value:  "",
 			EnvVar: "SCALEWAY_TOKEN",
+		},
+		cli.StringFlag{
+			Name:   "scaleway-userid",
+			Usage:  "Scaleway UserID",
+			Value:  "",
+			EnvVar: "SCALEWAY_USERID",
 		},
 		cli.StringFlag{
 			Name:   "scaleway-organization",

--- a/src/github.com/nlamirault/go-scaleway/version/version.go
+++ b/src/github.com/nlamirault/go-scaleway/version/version.go
@@ -16,4 +16,4 @@
 package version
 
 // Version represents the application version using SemVer
-const Version string = "0.6.0"
+const Version string = "0.7.0-RC1"


### PR DESCRIPTION
Salut, 
since the UserID and OrganizationID is quite cryptic and can not be obtained from the website user account, i slightly refactured your code:
Now, only the tokenID is necessary to execute all API commands. The userID and organizationID is programmatically derived from the tokenID when needed. It can still be set explicitly by the user via the Global Options.

I also fixed the Server struct (the *arch* attribute was not working) and changed it so that the name of the image and the server's running state are printed to the CLI as well.

Signed-off-by: Jan Broer <janeczku@yahoo.de>